### PR TITLE
Keep user data/files when upgrading; checksum default theme files

### DIFF
--- a/doc/PRE_UPGRADE.d/3.6.0~ynh2.md
+++ b/doc/PRE_UPGRADE.d/3.6.0~ynh2.md
@@ -1,0 +1,1 @@
+This upgrade will retain files in __INSTALL_DIR__/data/, __INSTALL_DIR__/plugins/, and __INSTALL_DIR__/themes/ except for __INSTALL_DIR__/themes/sky/ which will be upgraded to the latest version. If you've altered the default php or css files in the sky theme, they will moved to /var/cache/yunohost/appconfbackup/__INSTALL_DIR__/themes/sky/

--- a/doc/PRE_UPGRADE.d/3.6.0~ynh2_fr.md
+++ b/doc/PRE_UPGRADE.d/3.6.0~ynh2_fr.md
@@ -1,0 +1,1 @@
+Cette mise à jour conservera les fichiers dans __INSTALL_DIR__/data/, __INSTALL_DIR__/plugins/, et __INSTALL_DIR__/themes/ sauf pour __INSTALL_DIR__/themes/sky/ qui sera mis à jour vers la dernière version. Si vous avez modifié les fichiers php ou css par défaut dans le thème sky, ils seront déplacés vers /var/cache/yunohost/appconfbackup/__INSTALL_DIR_/themes/sky/

--- a/scripts/install
+++ b/scripts/install
@@ -26,6 +26,12 @@ ynh_config_add_phpfpm
 ynh_config_add_nginx
 
 #=================================================
+# SKY THEME CHECKSUMS STORE
+#=================================================
+ynh_store_file_checksum $install_dir/themes/sky/theme.php
+ynh_store_file_checksum $install_dir/themes/sky/css/style.css
+
+#=================================================
 # END OF SCRIPT
 #=================================================
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -12,7 +12,7 @@ source /usr/share/yunohost/helpers
 ynh_script_progression "Upgrading source files..."
 
 # Download, check integrity, uncompress and patch the source from manifest.toml
-ynh_setup_source --dest_dir="$install_dir"
+ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="data plugins themes"
 
 #=================================================
 # REAPPLY SYSTEM CONFIGURATIONS

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -6,13 +6,24 @@
 
 source /usr/share/yunohost/helpers
 
+themes=""
+for d in "$install_dir/themes"/*; do
+    name="$(basename "$d")"
+    if [ "$name" != "sky" ]; then
+        themes="$themes themes/$name"
+    fi
+done
+
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
+ynh_backup_if_checksum_is_different $install_dir/themes/sky/theme.php
+ynh_backup_if_checksum_is_different $install_dir/themes/sky/css/style.css
+
 # Download, check integrity, uncompress and patch the source from manifest.toml
-ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="data plugins themes"
+ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="data plugins $themes"
 
 #=================================================
 # REAPPLY SYSTEM CONFIGURATIONS
@@ -22,6 +33,12 @@ ynh_script_progression "Upgrading system configurations related to $app..."
 ynh_config_add_phpfpm
 
 ynh_config_add_nginx
+
+#=================================================
+# SKY THEME CHECKSUMS STORE
+#=================================================
+ynh_store_file_checksum $install_dir/themes/sky/theme.php
+ynh_store_file_checksum $install_dir/themes/sky/css/style.css
 
 #=================================================
 # END OF SCRIPT


### PR DESCRIPTION
## Problem

- *upgrade does not keep files*
- *default theme (sky) updated periodically with releases*

## Solution

- *keep data & plugins directories, check theme directory for non-default themes to keep*
- *checksum default theme php/css files in case user-modified*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
